### PR TITLE
Fix Tests throwing errors rather than failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Here's a useful reference guide: https://www.w3schools.com/java/java_ref_string.
 ## Set up instructions
 - Fork this repository and clone the forked version to your machine
 - Open the root directory of the project in IntelliJ
+- Ignore the `./src/main/java/com.booleanuk/core/ExerciseBase.java` file, it's just there to make the tests give meaningful failure messages
 - Implement the requirements listed in comments in the `./src/main/java/com.booleanuk/core/Exercise.java` file
 - When ready to test your solution, open the `./src/test/java/com.booleanuk/core/ExerciseTest.java` file and click a "Run Test" button. You can either run the entire test suite via figure 1 in the screenshot below, or run a specific test via figure 2.
 

--- a/src/main/java/com/booleanuk/core/Exercise.java
+++ b/src/main/java/com/booleanuk/core/Exercise.java
@@ -1,6 +1,7 @@
 package com.booleanuk.core;
 
-public class Exercise {
+
+public class Exercise extends ExerciseBase {
     public int numOne = 8;
     public int numTwo = 16;
     public int numThree = 32;

--- a/src/main/java/com/booleanuk/core/ExerciseBase.java
+++ b/src/main/java/com/booleanuk/core/ExerciseBase.java
@@ -1,0 +1,14 @@
+package com.booleanuk.core;
+
+
+public class ExerciseBase {
+    public char lastLetter;
+    public float pi;
+    public double piD;
+    public String fullName;
+    public char tenthLetter;
+    public String lowerAlphabet;
+    public int alphabetLength;
+    public int remainder;
+
+}

--- a/src/test/java/com/booleanuk/core/ExerciseTest.java
+++ b/src/test/java/com/booleanuk/core/ExerciseTest.java
@@ -1,8 +1,12 @@
 package com.booleanuk.core;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ExerciseTest {
     Exercise exercise;
 
@@ -11,71 +15,85 @@ class ExerciseTest {
     }
 
     @Test
+    @Order(1)
     public void oneShouldBe24() {
         Assertions.assertEquals(24, this.exercise.numOnePlusTwo);
     }
 
     @Test
+    @Order(2)
     public void twoShouldBe512() {
         Assertions.assertEquals(512, this.exercise.numThreeTimesNumTwo);
     }
 
     @Test
+    @Order(3)
     public void threeShouldBe4() {
         Assertions.assertEquals(4, this.exercise.numThreeDividedByNumOne);
     }
 
     @Test
+    @Order(4)
     public void fourShouldBe24() {
         Assertions.assertEquals(24, this.exercise.numThreeMinusNumOne);
     }
 
     @Test
+    @Order(5)
     public void fiveShouldBe56() {
         Assertions.assertEquals(56, this.exercise.sum);
     }
 
     @Test
+    @Order(6)
     public void sixShouldBe7() {
         Assertions.assertEquals(7, this.exercise.numBytes);
     }
 
     @Test
+    @Order(7)
     public void sevenShouldBeZ() {
         Assertions.assertEquals('Z', this.exercise.lastLetter);
     }
 
     @Test
+    @Order(8)
     public void eightShouldBe3p14() {
         Assertions.assertEquals(3.14f, this.exercise.pi);
     }
 
     @Test
+    @Order(9)
     public void nineShouldBe3p14159() {
         Assertions.assertEquals(3.14159d, this.exercise.piD);
     }
 
     @Test
+    @Order(10)
     public void tenShouldBeJaneSmith() {
         Assertions.assertEquals("Jane Smith", this.exercise.fullName);
     }
 
     @Test
+    @Order(11)
     public void elevenShouldBeJ() {
         Assertions.assertEquals('J', this.exercise.tenthLetter);
     }
 
     @Test
+    @Order(12)
     public void twelveShouldBeLowerAlphabet() {
         Assertions.assertEquals("abcdefghijklmnopqrstuvwxyz", this.exercise.lowerAlphabet);
     }
 
     @Test
+    @Order(13)
     public void thirteenShouldBe26() {
         Assertions.assertEquals(26, this.exercise.alphabetLength);
     }
 
     @Test
+    @Order(14)
     public void fourteenShouldBe7() {
         Assertions.assertEquals(7, this.exercise.remainder);
     }


### PR DESCRIPTION
Added a base class to the Exercise class which contains public definitions for each of the variables/attributes they have to create in the Exercise and made Exercise inherit from it, that way the tests actually fail when they're run rather than causing an error because it can't find the various missing attributes.

Also added @TestMethodOrder to the Test class to make the Tests run and display their results in the order they are defined.